### PR TITLE
Add an `Fr` constructor for `SigningKey`s

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -1,7 +1,7 @@
 use rand::{thread_rng, Rng};
 
-use std::convert::TryFrom;
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use std::convert::TryFrom;
 
 use decaf377_rdsa::*;
 

--- a/src/batch.rs
+++ b/src/batch.rs
@@ -1,4 +1,4 @@
-//! Performs batch RedJubjub signature verification.
+//! Performs batch `decaf377-rdsa` signature verification.
 //!
 //! Batch verification asks whether *all* signatures in some set are valid,
 //! rather than asking whether *each* of them is valid. This allows sharing
@@ -155,18 +155,16 @@ impl Verifier {
     /// - h_G is the cofactor of the group;
     /// - P_G is the generator of the subgroup;
     ///
-    /// Since RedJubjub uses different subgroups for different types
-    /// of signatures, SpendAuth's and Binding's, we need to have yet
-    /// another point and associated scalar accumulator for all the
-    /// signatures of each type in our batch, but we can still
-    /// amortize computation nicely in one multiscalar multiplication:
+    /// Since `decaf377-rdsa` uses a different generator for each signature
+    /// domain, we have a separate scalar accumulator for each domain, but we
+    /// can still amortize computation nicely in one multiscalar multiplication:
     ///
     /// h_G * ( [-sum(z_i * s_i): i_type == SpendAuth]P_SpendAuth + [-sum(z_i * s_i): i_type == Binding]P_Binding + sum([z_i]R_i) + sum([z_i * c_i]VK_i) ) = 0_G
     ///
     /// As follows elliptic curve scalar multiplication convention,
     /// scalar variables are lowercase and group point variables
     /// are uppercase. This does not exactly match the RedDSA
-    /// notation in the [protocol specification §B.1][ps].
+    /// notation in the [Zcash protocol specification §B.1][ps].
     ///
     /// [ps]: https://zips.z.cash/protocol/protocol.pdf#reddsabatchverify
     #[allow(non_snake_case)]

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,6 @@
 use thiserror::Error;
 
-/// An error related to RedJubJub signatures.
+/// An error related to `decaf377-rdsa` signatures.
 #[derive(Error, Debug, Copy, Clone, Eq, PartialEq)]
 pub enum Error {
     /// The encoding of a signing key was malformed.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,9 +8,6 @@ mod signature;
 mod signing_key;
 mod verification_key;
 
-/// An element of the JubJub scalar field used for randomization of public and secret keys.
-pub type Randomizer = decaf377::Fr;
-
 use hash::HStar;
 
 pub use domain::{Binding, Domain, SpendAuth};
@@ -18,3 +15,5 @@ pub use error::Error;
 pub use signature::Signature;
 pub use signing_key::SigningKey;
 pub use verification_key::{VerificationKey, VerificationKeyBytes};
+
+pub use decaf377::Fr;

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -2,7 +2,7 @@ use std::marker::PhantomData;
 
 use crate::Domain;
 
-/// A RedJubJub signature.
+/// A `decaf377-rdsa` signature.
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Signature<D: Domain> {

--- a/src/signing_key.rs
+++ b/src/signing_key.rs
@@ -9,7 +9,7 @@ use ark_ff::PrimeField;
 
 use crate::{Domain, Error, Randomizer, Signature, SpendAuth, VerificationKey};
 
-/// A RedJubJub signing key.
+/// A `decaf377-rdsa` signing key.
 #[derive(Copy, Clone, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(try_from = "SerdeHelper"))]

--- a/src/signing_key.rs
+++ b/src/signing_key.rs
@@ -3,11 +3,11 @@ use std::{
     marker::PhantomData,
 };
 
+use ark_ff::PrimeField;
 use decaf377::{Fr, FrExt};
 use rand_core::{CryptoRng, RngCore};
-use ark_ff::PrimeField;
 
-use crate::{Domain, Error, Randomizer, Signature, SpendAuth, VerificationKey};
+use crate::{Domain, Error, Signature, SpendAuth, VerificationKey};
 
 /// A `decaf377-rdsa` signing key.
 #[derive(Copy, Clone, Debug)]
@@ -38,8 +38,13 @@ impl<D: Domain> TryFrom<[u8; 32]> for SigningKey<D> {
     fn try_from(bytes: [u8; 32]) -> Result<Self, Self::Error> {
         use ark_serialize::CanonicalDeserialize;
         let sk = Fr::deserialize(&bytes[..]).map_err(|_| Error::MalformedSigningKey)?;
-        let pk = VerificationKey::from(&sk);
-        Ok(SigningKey { sk, pk })
+        Ok(Self::new_from_field(sk))
+    }
+}
+
+impl<D: Domain> From<Fr> for SigningKey<D> {
+    fn from(sk: Fr) -> Self {
+        Self::new_from_field(sk)
     }
 }
 
@@ -62,7 +67,7 @@ impl<D: Domain> From<SigningKey<D>> for SerdeHelper {
 
 impl SigningKey<SpendAuth> {
     /// Randomize this public key with the given `randomizer`.
-    pub fn randomize(&self, randomizer: &Randomizer) -> SigningKey<SpendAuth> {
+    pub fn randomize(&self, randomizer: &Fr) -> SigningKey<SpendAuth> {
         let sk = self.sk + randomizer;
         let pk = VerificationKey::from(&sk);
         SigningKey { sk, pk }
@@ -70,13 +75,23 @@ impl SigningKey<SpendAuth> {
 }
 
 impl<D: Domain> SigningKey<D> {
-    /// Generate a new signing key.
+    /// Create a new signing key from the supplied `rng`.
     pub fn new<R: RngCore + CryptoRng>(mut rng: R) -> SigningKey<D> {
         let sk = {
             let mut bytes = [0; 64];
             rng.fill_bytes(&mut bytes);
             Fr::from_le_bytes_mod_order(&bytes[..])
         };
+        Self::new_from_field(sk)
+    }
+
+    /// Use the supplied field element as the signing key directly.
+    ///
+    /// # Warning
+    ///
+    /// This function exists to allow custom key derivation; it's the caller's
+    /// responsibility to ensure that the input was generated securely.
+    pub fn new_from_field(sk: Fr) -> SigningKey<D> {
         let pk = VerificationKey::from(&sk);
         SigningKey { sk, pk }
     }

--- a/src/verification_key.rs
+++ b/src/verification_key.rs
@@ -9,7 +9,7 @@ use decaf377::{Fr, FrExt};
 use crate::{domain::Sealed, Domain, Error, Randomizer, Signature, SpendAuth};
 
 /// A refinement type for `[u8; 32]` indicating that the bytes represent
-/// an encoding of a RedJubJub verification key.
+/// an encoding of a `decaf377-rdsa` verification key.
 ///
 /// This is useful for representing a compressed verification key; the
 /// [`VerificationKey`] type in this library holds other decompressed state
@@ -43,19 +43,11 @@ impl<D: Domain> Hash for VerificationKeyBytes<D> {
     }
 }
 
-/// A valid RedJubJub verification key.
+/// A valid `decaf377-rdsa` verification key.
 ///
 /// This type holds decompressed state used in signature verification; if the
 /// verification key may not be used immediately, it is probably better to use
 /// [`VerificationKeyBytes`], which is a refinement type for `[u8; 32]`.
-///
-/// ## Consensus properties
-///
-/// The `TryFrom<VerificationKeyBytes>` conversion performs the following Zcash
-/// consensus rule checks:
-///
-/// 1. The check that the bytes are a canonical encoding of a verification key;
-/// 2. The check that the verification key is not a point of small order.
 #[derive(Copy, Clone, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(try_from = "VerificationKeyBytes<D>"))]

--- a/src/verification_key.rs
+++ b/src/verification_key.rs
@@ -6,7 +6,7 @@ use std::{
 
 use decaf377::{Fr, FrExt};
 
-use crate::{domain::Sealed, Domain, Error, Randomizer, Signature, SpendAuth};
+use crate::{domain::Sealed, Domain, Error, Signature, SpendAuth};
 
 /// A refinement type for `[u8; 32]` indicating that the bytes represent
 /// an encoding of a `decaf377-rdsa` verification key.
@@ -96,7 +96,7 @@ impl VerificationKey<SpendAuth> {
     /// Randomize this verification key with the given `randomizer`.
     ///
     /// Randomization is only supported for `SpendAuth` keys.
-    pub fn randomize(&self, randomizer: &Randomizer) -> VerificationKey<SpendAuth> {
+    pub fn randomize(&self, randomizer: &Fr) -> VerificationKey<SpendAuth> {
         let point = self.point + (SpendAuth::basepoint() * randomizer);
         let bytes = VerificationKeyBytes {
             bytes: point.compress().into(),

--- a/tests/proptests.rs
+++ b/tests/proptests.rs
@@ -133,7 +133,7 @@ proptest! {
             use ark_ff::PrimeField;
             let mut bytes = [0; 64];
             rng.fill_bytes(&mut bytes[..]);
-            Randomizer::from_le_bytes_mod_order(&bytes)
+            Fr::from_le_bytes_mod_order(&bytes)
         };
 
         let sk = SigningKey::<SpendAuth>::new(&mut rng);


### PR DESCRIPTION
This doesn't expose much additional API surface, because we already had to expose the field elements in the API as randomizers.

Also update some stale doc comments.