### PR TITLE
feat: add method for checking if VerificationKey is identity

### DIFF
--- a/src/verification_key.rs
+++ b/src/verification_key.rs
@@ -146,6 +146,11 @@ impl<D: Domain> VerificationKey<D> {
         self.verify_prehashed(signature, c)
     }
 
+    /// Convenience method for identity checks.
+    pub fn is_identity(&self) -> bool {
+        self.point.is_identity()
+    }
+
     /// Verify a purported `signature` with a prehashed challenge.
     #[allow(non_snake_case)]
     pub(crate) fn verify_prehashed(&self, signature: &Signature<D>, c: Fr) -> Result<(), Error> {


### PR DESCRIPTION
This is needed for the identity checks as part of the `SpendProof`
verification (checking that `ak` is not identity)