### PR TITLE
Make `SpendAuth` signatures independent of the decaf377 hash-to-group mechanism.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,12 @@ the library also provides `VerificationKeyBytes`, a [refinement] of a
 verification key. This allows the `VerificationKey` type to cache
 verification checks related to the verification key encoding.
 
+## WARNING
+
+This code is a work-in-progress, and the entire specification is still subject
+to change.  In particular, it's likely that the basepoint used for binding
+signatures will change in the future as the `decaf377` spec evolves.
+
 ## Examples
 
 Creating a spend authorization signature, serializing and deserializing it, and

--- a/src/domain.rs
+++ b/src/domain.rs
@@ -40,7 +40,7 @@ pub(crate) mod private {
     }
     impl Sealed for SpendAuth {
         fn basepoint() -> decaf377::Element {
-            hash_to_group(b"decaf377-rdsa-spendauth")
+            decaf377::basepoint()
         }
     }
 }


### PR DESCRIPTION
Because the hash-to-group mechanism for decaf377 is still subject to change (we
need to select the quadratic nonresidue together with an optimized square root
algorithm), all uses of it are also subject to change.  Making `SpendAuth`
signatures independent of this evolution means that the (longer-term) spend
authorization keys are less likely to be invalidated.