### PR TITLE
Add nicer hex-formatted Debug impls

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ serde = { version = "1", optional = true, features = ["derive"] }
 thiserror = "1.0"
 ark-serialize = "0.3"
 ark-ff = "0.3"
+hex = "0.4"
 
 [dev-dependencies]
 bincode = "1"

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -1,14 +1,30 @@
 use std::marker::PhantomData;
 
-use crate::Domain;
+use crate::{Binding, Domain, SpendAuth};
 
 /// A `decaf377-rdsa` signature.
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[derive(Copy, Clone, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Signature<D: Domain> {
     pub(crate) r_bytes: [u8; 32],
     pub(crate) s_bytes: [u8; 32],
     pub(crate) _marker: PhantomData<D>,
+}
+
+impl std::fmt::Debug for Signature<Binding> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("Signature<Binding>")
+            .field(&hex::encode(&<[u8; 64]>::from(*self)))
+            .finish()
+    }
+}
+
+impl std::fmt::Debug for Signature<SpendAuth> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("Signature<SpendAuth>")
+            .field(&hex::encode(&<[u8; 64]>::from(*self)))
+            .finish()
+    }
 }
 
 impl<D: Domain> From<[u8; 64]> for Signature<D> {

--- a/src/signing_key.rs
+++ b/src/signing_key.rs
@@ -7,10 +7,10 @@ use ark_ff::PrimeField;
 use decaf377::{FieldExt, Fr};
 use rand_core::{CryptoRng, RngCore};
 
-use crate::{Domain, Error, Signature, SpendAuth, VerificationKey};
+use crate::{Binding, Domain, Error, Signature, SpendAuth, VerificationKey};
 
 /// A `decaf377-rdsa` signing key.
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(try_from = "SerdeHelper"))]
 #[cfg_attr(feature = "serde", serde(into = "SerdeHelper"))]
@@ -18,6 +18,22 @@ use crate::{Domain, Error, Signature, SpendAuth, VerificationKey};
 pub struct SigningKey<D: Domain> {
     sk: Fr,
     pk: VerificationKey<D>,
+}
+
+impl std::fmt::Debug for SigningKey<Binding> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("SigningKey<Binding>")
+            .field(&hex::encode(&<[u8; 32]>::from(*self)))
+            .finish()
+    }
+}
+
+impl std::fmt::Debug for SigningKey<SpendAuth> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("SigningKey<SpendAuth>")
+            .field(&hex::encode(&<[u8; 32]>::from(*self)))
+            .finish()
+    }
 }
 
 impl<'a, D: Domain> From<&'a SigningKey<D>> for VerificationKey<D> {

--- a/src/verification_key.rs
+++ b/src/verification_key.rs
@@ -6,7 +6,7 @@ use std::{
 
 use decaf377::{FieldExt, Fr};
 
-use crate::{domain::Sealed, Domain, Error, Signature, SpendAuth};
+use crate::{domain::Sealed, Binding, Domain, Error, Signature, SpendAuth};
 
 /// A refinement type for `[u8; 32]` indicating that the bytes represent
 /// an encoding of a `decaf377-rdsa` verification key.
@@ -14,7 +14,7 @@ use crate::{domain::Sealed, Domain, Error, Signature, SpendAuth};
 /// This is useful for representing a compressed verification key; the
 /// [`VerificationKey`] type in this library holds other decompressed state
 /// used in signature verification.
-#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+#[derive(Copy, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct VerificationKeyBytes<D: Domain> {
     pub(crate) bytes: [u8; 32],
@@ -54,7 +54,7 @@ impl<D: Domain> Hash for VerificationKeyBytes<D> {
 /// This type holds decompressed state used in signature verification; if the
 /// verification key may not be used immediately, it is probably better to use
 /// [`VerificationKeyBytes`], which is a refinement type for `[u8; 32]`.
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(try_from = "VerificationKeyBytes<D>"))]
 #[cfg_attr(feature = "serde", serde(into = "VerificationKeyBytes<D>"))]
@@ -172,5 +172,37 @@ impl<D: Domain> VerificationKey<D> {
         } else {
             Err(Error::InvalidSignature)
         }
+    }
+}
+
+impl std::fmt::Debug for VerificationKey<Binding> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("VerificationKey<Binding>")
+            .field(&hex::encode(&<[u8; 32]>::from(*self)))
+            .finish()
+    }
+}
+
+impl std::fmt::Debug for VerificationKey<SpendAuth> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("VerificationKey<SpendAuth>")
+            .field(&hex::encode(&<[u8; 32]>::from(*self)))
+            .finish()
+    }
+}
+
+impl std::fmt::Debug for VerificationKeyBytes<Binding> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("VerificationKeyBytes<Binding>")
+            .field(&hex::encode(&<[u8; 32]>::from(*self)))
+            .finish()
+    }
+}
+
+impl std::fmt::Debug for VerificationKeyBytes<SpendAuth> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("VerificationKeyBytes<SpendAuth>")
+            .field(&hex::encode(&<[u8; 32]>::from(*self)))
+            .finish()
     }
 }

--- a/tests/proptests.rs
+++ b/tests/proptests.rs
@@ -6,7 +6,7 @@ use rand_core::{CryptoRng, RngCore};
 use decaf377_rdsa::*;
 
 /// A signature test-case, containing signature data and expected validity.
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 struct SignatureCase<D: Domain> {
     msg: Vec<u8>,
     sig: Signature<D>,


### PR DESCRIPTION
Now produces debug output like
```
Signature<SpendAuth>("f008bc2a80174fd0a450f28f86ddf1f2c2e20acd8986edbe6a8cf1ad5575fa02044fcc0ec0faf138ab26d39a600d723e0e2a671304a89c86b641cad4829f8604")
VerificationKey<SpendAuth>("26bc0fe0b14a3c4cbc125b721475ca57cf24b5b12ff740bd652a88c531b68506")
```