### PR TITLE
Fix Eq impls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+# CHANGELOG
+
+Entries are listed in reverse chronological order.
+
+# 0.2.0
+
+* Generalize `Eq`, `PartialEq` impls for `VerificationKeyBytes`, `Signature` to avoid a derived `D: Domain + PartialEq` bound.
+* Add `Eq`, `PartialEq` impls for `VerificationKey`.
+
+# 0.1.0
+
+* Initial development version

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "decaf377-rdsa"
 edition = "2018"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Penumbra Labs <team@penumbra.zone>"]
 readme = "README.md"
 license = "MIT OR Apache-2.0"

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -3,7 +3,7 @@ use std::marker::PhantomData;
 use crate::{Binding, Domain, SpendAuth};
 
 /// A `decaf377-rdsa` signature.
-#[derive(Copy, Clone, Eq, PartialEq)]
+#[derive(Copy, Clone)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Signature<D: Domain> {
     pub(crate) r_bytes: [u8; 32],
@@ -49,3 +49,11 @@ impl<D: Domain> From<Signature<D>> for [u8; 64] {
         bytes
     }
 }
+
+impl<D: Domain> std::cmp::PartialEq for Signature<D> {
+    fn eq(&self, other: &Self) -> bool {
+        self.r_bytes.eq(&other.r_bytes) && self.s_bytes.eq(&other.s_bytes)
+    }
+}
+
+impl<D: Domain> std::cmp::Eq for Signature<D> {}

--- a/src/verification_key.rs
+++ b/src/verification_key.rs
@@ -14,7 +14,7 @@ use crate::{domain::Sealed, Binding, Domain, Error, Signature, SpendAuth};
 /// This is useful for representing a compressed verification key; the
 /// [`VerificationKey`] type in this library holds other decompressed state
 /// used in signature verification.
-#[derive(Copy, Clone, PartialEq, Eq)]
+#[derive(Copy, Clone)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct VerificationKeyBytes<D: Domain> {
     pub(crate) bytes: [u8; 32],
@@ -174,6 +174,21 @@ impl<D: Domain> VerificationKey<D> {
         }
     }
 }
+
+impl<D: Domain> std::cmp::PartialEq for VerificationKey<D> {
+    fn eq(&self, other: &Self) -> bool {
+        self.bytes.eq(&other.bytes)
+    }
+}
+
+impl<D: Domain> std::cmp::PartialEq for VerificationKeyBytes<D> {
+    fn eq(&self, other: &Self) -> bool {
+        self.bytes.eq(&other.bytes)
+    }
+}
+
+impl<D: Domain> std::cmp::Eq for VerificationKey<D> {}
+impl<D: Domain> std::cmp::Eq for VerificationKeyBytes<D> {}
 
 impl std::fmt::Debug for VerificationKey<Binding> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {


### PR DESCRIPTION
Adds `Eq`, `PartialEq` to `VerificationKey` and removes derived bounds for the existing impls.