### PR TITLE
Add .to_bytes() methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Entries are listed in reverse chronological order.
 
+# 0.3.0
+
+* Add convenience `.to_bytes()` methods that work like `.into()` but don't require type inference.
+
 # 0.2.0
 
 * Generalize `Eq`, `PartialEq` impls for `VerificationKeyBytes`, `Signature` to avoid a derived `D: Domain + PartialEq` bound.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "decaf377-rdsa"
 edition = "2018"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Penumbra Labs <team@penumbra.zone>"]
 readme = "README.md"
 license = "MIT OR Apache-2.0"

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -11,6 +11,18 @@ pub struct Signature<D: Domain> {
     pub(crate) _marker: PhantomData<D>,
 }
 
+impl<D: Domain> Signature<D> {
+    /// Returns the bytes of the signature.
+    ///
+    /// This is the same as `.into()`, but does not require type inference.
+    pub fn to_bytes(&self) -> [u8; 64] {
+        let mut bytes = [0; 64];
+        bytes[0..32].copy_from_slice(&self.r_bytes[..]);
+        bytes[32..64].copy_from_slice(&self.s_bytes[..]);
+        bytes
+    }
+}
+
 impl std::fmt::Debug for Signature<Binding> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_tuple("Signature<Binding>")
@@ -43,10 +55,7 @@ impl<D: Domain> From<[u8; 64]> for Signature<D> {
 
 impl<D: Domain> From<Signature<D>> for [u8; 64] {
     fn from(sig: Signature<D>) -> [u8; 64] {
-        let mut bytes = [0; 64];
-        bytes[0..32].copy_from_slice(&sig.r_bytes[..]);
-        bytes[32..64].copy_from_slice(&sig.s_bytes[..]);
-        bytes
+        sig.to_bytes()
     }
 }
 

--- a/src/signing_key.rs
+++ b/src/signing_key.rs
@@ -54,6 +54,15 @@ impl<D: Domain> From<SigningKey<D>> for [u8; 32] {
     }
 }
 
+impl<D: Domain> SigningKey<D> {
+    /// Returns the byte encoding of the signing key.
+    ///
+    /// This is the same as `.into()`, but does not require type inference.
+    pub fn to_bytes(&self) -> [u8; 32] {
+        self.sk.to_bytes()
+    }
+}
+
 impl<D: Domain> TryFrom<[u8; 32]> for SigningKey<D> {
     type Error = Error;
 

--- a/src/verification_key.rs
+++ b/src/verification_key.rs
@@ -70,6 +70,15 @@ impl<D: Domain> From<VerificationKey<D>> for VerificationKeyBytes<D> {
     }
 }
 
+impl<D: Domain> VerificationKey<D> {
+    /// Returns the byte encoding of the verification key.
+    ///
+    /// This is the same as `.into()`, but does not require type inference.
+    pub fn to_bytes(&self) -> [u8; 32] {
+        self.bytes.bytes
+    }
+}
+
 impl<D: Domain> From<VerificationKey<D>> for [u8; 32] {
     fn from(pk: VerificationKey<D>) -> [u8; 32] {
         pk.bytes.bytes


### PR DESCRIPTION
These work like `.into()` but don't require type inference.