### PR TITLE
chore: update decaf377 to published 0.3 crates release, disable default parallelism

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,13 +10,13 @@ description = "decaf377-rdsa is a randomizable signature scheme using the decaf3
 [dependencies]
 blake2b_simd = "0.5"
 byteorder = "1.3"
-decaf377 = { git = "https://github.com/penumbra-zone/decaf377" }
+decaf377 = { version= "0.3", default-features=false }
 digest = "0.9"
 rand_core = "0.6"
 serde = { version = "1", optional = true, features = ["derive"] }
 thiserror = "1.0"
 ark-serialize = "0.3"
-ark-ff = "0.3"
+ark-ff =  { version = "0.3", default-features=false }
 hex = "0.4"
 
 [dev-dependencies]
@@ -32,4 +32,6 @@ name = "bench"
 harness = false
 
 [features]
-default = ["serde"]
+default = ["serde", "std"]
+std = ["ark-ff/std"]
+parallel = ["ark-ff/parallel", "decaf377/parallel"]


### PR DESCRIPTION
NOTE: when this is merged, switch the penumbra monorepo back to `main` branch of this crate