### PR TITLE
Add sign_deterministic and improve nonce generation.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "decaf377-rdsa"
 edition = "2021"
-version = "0.8.0"
+version = "0.8.1"
 authors = ["Penumbra Labs <team@penumbralabs.xyz>"]
 readme = "README.md"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
This commit changes the nonce generation to insert the secret key as the first 32 bytes of the randomness used to compute the nonce.  This ensures that if a weak or no RNG is supplied, nonces are still unpredictable without knowledge of the secret key.

We do not otherwise deviate from the original RedDSA choice of 80 bytes of randomness.