### PR TITLE
feat(backend) Add u32_backend feature to enable decaf377 u32 support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ default = ["serde", "std"]
 alloc = ["ark-ff", "ark-serialize"]
 std = ["alloc", "ark-ff/std", "blake2b_simd/std", "decaf377/arkworks", "digest/std", "hex/std", "rand_core/std", "thiserror"]
 parallel = ["ark-ff/parallel", "decaf377/parallel"]
+u32_backend = ["decaf377/u32_backend"]
 
 # Create profile for running checks in CI that are mostly "release" mode,
 # but also checking the `debug_assert `lines.


### PR DESCRIPTION
This PR introduces a new feature flag, `u32_backend`, to the poseidon377 crate, allowing users to explicitly select the u32 backend for the decaf377 dependency.

This is crucial for projects that require consistent use of the u32 backend across their dependencies to avoid potential subtle errors associated with backend mismatches.
