### PR TITLE
update to released version of decaf377 (0.9.0)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/penumbra-zone/decaf377-rdsa"
 [dependencies]
 # No Alloc, No Std
 blake2b_simd = { version = "0.5", default-features = false }
-decaf377 = { git = "https://github.com/penumbra-zone/decaf377", rev = "e26c88c896d9e3da4677bfe9ba127ce45979e0b2", default-features = false }
+decaf377 = { version = "0.9.0", default-features = false }
 digest = { version = "0.9", default-features = false }
 rand_core = { version = "0.6", default-features = false }
 hex = { version = "0.4", default-features = false }


### PR DESCRIPTION
To release to crates.io we need to bump to a published release of decaf377 