### PR TITLE
update decaf377 deps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/penumbra-zone/decaf377-rdsa"
 [dependencies]
 # No Alloc, No Std
 blake2b_simd = { version = "0.5", default-features = false }
-decaf377 = { version = "0.9.0", default-features = false }
+decaf377 = { version = "0.10.0", default-features = false }
 digest = { version = "0.9", default-features = false }
 rand_core = { version = "0.6", default-features = false }
 hex = { version = "0.4", default-features = false }


### PR DESCRIPTION
updates decaf377 crate deps to `0.10.0`. after merging, can we cut a `0.8.0` tagged release of `decaf377-rdsa`? cc @redshiftzero 