### PR TITLE
decaf377-rdsa: arkworks 0.5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,8 +18,8 @@ hex = { version = "0.4", default-features = false }
 # Only to satisfy Cargo
 zeroize = { version = "1.7", default-features = false }
 # Alloc, No Std
-ark-ff = { version = "0.4", optional = true, default-features = false }
-ark-serialize = { version = "0.4", optional = true }
+ark-ff = { version = "0.5", optional = true, default-features = false }
+ark-serialize = { version = "0.5", optional = true }
 # Std
 serde = { version = "1", optional = true, features = ["derive"] }
 thiserror = { version = "1.0", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/penumbra-zone/decaf377-rdsa"
 [dependencies]
 # No Alloc, No Std
 blake2b_simd = { version = "0.5", default-features = false }
-decaf377 = { version = "0.10.1", default-features = false }
+decaf377 = { default-features = false, git = "https://github.com/penumbra-zone/decaf377", branch = "arkworks-0.5" }
 digest = { version = "0.9", default-features = false }
 rand_core = { version = "0.6", default-features = false }
 hex = { version = "0.4", default-features = false }


### PR DESCRIPTION
upgrade arkworks dependencies to `v0.5` in decaf377-rdsa